### PR TITLE
restructure cli logic and add size param

### DIFF
--- a/src/reprosyn/cli.py
+++ b/src/reprosyn/cli.py
@@ -1,11 +1,52 @@
 import click
+import sys
 
 from reprosyn.methods.mbi.cli import mstcommand
 
 
-@click.group(help="A cli tool synthesising the 1% census")
-def main():
-    pass
+class Dataset(object):
+    def __init__(self, file=None, out=None, size=None):
+        self.file = file
+        self.out = out
+        self.size = size
+
+
+@click.group(
+    options_metavar="[GLOBAL OPTIONS]",
+    subcommand_metavar="[GENERATOR]",
+)
+@click.option(
+    "--file",
+    type=click.File("rt"),
+    help="[REQUIRED] filepath to dataset or STDIN",
+    default=sys.stdin,
+)
+@click.option(
+    "--out",
+    help="filepath to write output to, omit for STDOUT",
+    type=click.File("at"),
+    default=sys.stdout,
+)
+@click.option(
+    "--size",
+    type=int,
+    help="number of rows to synthesise",
+)
+@click.pass_context
+def main(ctx, file, out, size):
+    """ "A cli tool synthesising the 1% census"
+
+    Usage: rsyn <global options> <generator> <generator options>
+
+    If --file/STDIN not given, help is printed.
+
+    Examples: \n
+
+    rsyn --file census.csv mst \n
+    census.csv > rsyn mst
+    """
+    ctx.obj = Dataset(file, out, size)
+    # print(f"Executing generator {ctx.invoked_subcommand}")
 
 
 main.add_command(mstcommand)

--- a/src/reprosyn/methods/mbi/cli.py
+++ b/src/reprosyn/methods/mbi/cli.py
@@ -1,21 +1,11 @@
-import sys
-
 import click
 from reprosyn.methods.mbi.mst import mstmain
 
 
-@click.command("mst", short_help="NIST-winning MST")
-@click.option(
-    "--file",
-    type=click.File("rt"),
-    help="filepath to dataset or STDIN",
-    default=sys.stdin,
-)
-@click.option(
-    "--out",
-    help="filepath to write output to, omit for STDOUT",
-    type=click.File("at"),
-    default=sys.stdout,
+@click.command(
+    "mst",
+    short_help="NIST-winning MST",
+    options_metavar="[GENERATOR OPTIONS]",
 )
 # @click.option("--degree", type=int, default=2, help="degree of marginals in workload")
 # @click.option(
@@ -24,24 +14,26 @@ from reprosyn.methods.mbi.mst import mstmain
 #     default=10000,
 #     help="maximum number of cells for marginals in workload",
 # )
-# @click.option(
-#     "--epsilon",
-#     type=float,
-#     default=1.0,
-#     help="privacy parameter",
-# )
-def mstcommand(file, out):
-    """Runs MST on --file
+@click.option(
+    "--epsilon",
+    type=float,
+    default=1.0,
+    help="privacy parameter",
+)
+@click.pass_obj
+def mstcommand(obj, epsilon):
+    """Runs MST on --file or STDIN
 
-    Usage
+    See rsyn --help for general use.
 
-    rsyn mst --file census.csv \n
+    Examples:
+
+    rsyn --file census.csv mst  \n
     rsyn mst < census.csv
     """
-
-    if not file.isatty():
-        output = mstmain(dataset=file)
-        click.echo(output.df, file=out)
+    if not obj.file.isatty():
+        output = mstmain(dataset=obj.file, size=obj.size)
+        click.echo(output.df, file=obj.out)
     else:
         mstcommand.main(["--help"])
 


### PR DESCRIPTION
Changes made: 

- separate global options (`--file`, `--out`, `--size`) into a main cli call from generator-specific options:
- save the global options into a `Dataset` object, that gets passed to the subcommands.
- alter `mst.py` to take a `size` option, pass this to `MST()`