### PR TITLE
overrides default map with config

### DIFF
--- a/src/reprosyn/cli.py
+++ b/src/reprosyn/cli.py
@@ -28,7 +28,7 @@ class Generator(object):
     def set_config_path(self, method):
         self.config = path.join(
             self.configfolder,
-            f"mst_{self.config}",
+            f"{method}_{self.config}",
         )
 
 
@@ -71,7 +71,7 @@ class Generator(object):
     help="directory for method configs",
 )
 @click.pass_context
-def main(ctx, file, out, size, generateconfig, config, configfolder):
+def main(ctx, **kwargs):
     """ "A cli tool synthesising the 1% census"
 
     Usage: rsyn <global options> <generator> <generator options>
@@ -84,14 +84,7 @@ def main(ctx, file, out, size, generateconfig, config, configfolder):
     census.csv > rsyn mst
     """
 
-    ctx.obj = Generator(
-        file,
-        out,
-        size,
-        generateconfig,
-        config,
-        configfolder,
-    )
+    ctx.obj = Generator(**kwargs)
 
     # print(f"Executing generator {ctx.invoked_subcommand}")
 

--- a/src/reprosyn/cli.py
+++ b/src/reprosyn/cli.py
@@ -5,6 +5,8 @@ from datetime import datetime
 
 from reprosyn.methods.mbi.cli import mstcommand
 
+import json
+
 # Helper class for manipulating options across reprosyn
 
 
@@ -25,11 +27,8 @@ class Generator(object):
         self.config = config
         self.configfolder = configfolder
 
-    def set_config_path(self, method):
-        self.config = path.join(
-            self.configfolder,
-            f"{method}_{self.config}",
-        )
+    def get_config_path(self):
+        return path.join(self.configfolder, self.config)
 
 
 @click.group(
@@ -86,6 +85,10 @@ def main(ctx, **kwargs):
 
     ctx.obj = Generator(**kwargs)
 
+    if ctx.obj.config != "-":
+        with click.open_file(ctx.obj.get_config_path(), "r") as f:
+            config_params = json.load(f)
+        ctx.default_map = {ctx.invoked_subcommand: config_params}
     # print(f"Executing generator {ctx.invoked_subcommand}")
 
 

--- a/src/reprosyn/methods/mbi/cli.py
+++ b/src/reprosyn/methods/mbi/cli.py
@@ -41,18 +41,18 @@ from reprosyn.methods.mbi.mst import mstmain
     default=2,
     help="degree of marginals in workload",
 )
-@click.option(
-    "--num_marginals",
-    type=int,
-    default=None,
-    help="number of marginals in workload",
-)
-@click.option(
-    "--max_cells",
-    type=int,
-    default=10000,
-    help="maximum number of cells for marginals in workload",
-)
+# @click.option(
+#     "--num_marginals",
+#     type=int,
+#     default=None,
+#     help="number of marginals in workload",
+# )
+# @click.option(
+#     "--max_cells",
+#     type=int,
+#     default=10000,
+#     help="maximum number of cells for marginals in workload",
+# )
 @click.pass_obj
 def mstcommand(sdg, **kwargs):
     """Runs MST on --file or STDIN

--- a/src/reprosyn/methods/mbi/cli.py
+++ b/src/reprosyn/methods/mbi/cli.py
@@ -2,28 +2,59 @@ import click
 import json
 from reprosyn.methods.mbi.mst import mstmain
 
+# params = {}
+# params["dataset"] = "../data/adult.csv"
+# params["domain"] = "../data/adult-domain.json"
+# params["epsilon"] = 1.0
+# params["delta"] = 1e-9
+# params["degree"] = 2
+# params["num_marginals"] = None
+# params["max_cells"] = 10000
+
 
 @click.command(
     "mst",
     short_help="NIST-winning MST",
     options_metavar="[GENERATOR OPTIONS]",
 )
-# @click.option("--degree", type=int, default=2, help="degree of marginals in workload")
-# @click.option(
-#     "--max_cells",
-#     type=int,
-#     default=10000,
-#     help="maximum number of cells for marginals in workload",
-# )
+@click.option(
+    "--domain",
+    type=click.File(),
+    default=None,
+    help="domain to use, default to get_domain_dict()",
+)
 @click.option(
     "--epsilon",
     type=float,
     default=1.0,
-    help="privacy parameter",
+    help="privacy parameter epsilon",
+)
+@click.option(
+    "--delta",
+    type=float,
+    default=1e-9,
+    help="privacy parameter delta",
+)
+@click.option(
+    "--degree",
+    type=int,
+    default=2,
+    help="degree of marginals in workload",
+)
+@click.option(
+    "--num_marginals",
+    type=int,
+    default=None,
+    help="number of marginals in workload",
+)
+@click.option(
+    "--max_cells",
+    type=int,
+    default=10000,
+    help="maximum number of cells for marginals in workload",
 )
 @click.pass_obj
-@click.pass_context
-def mstcommand(ctx, obj, epsilon):
+def mstcommand(sdg, **kwargs):
     """Runs MST on --file or STDIN
 
     See rsyn --help for general use.
@@ -33,17 +64,18 @@ def mstcommand(ctx, obj, epsilon):
     rsyn --file census.csv mst  \n
     rsyn mst < census.csv
     """
+
     # all methods will need the config generation so this should be moved to a global method.
-    if obj.generateconfig:
-        if obj.config != "-":
-            obj.set_config_path("mst")
-        with click.open_file(obj.config, "w") as outfile:
-            click.echo(f"Saving to config file to {obj.config}")
-            json.dump(ctx.params, outfile)
+    if sdg.generateconfig:
+        if sdg.config != "-":
+            sdg.set_config_path("mst")
+        with click.open_file(sdg.config, "w") as outfile:
+            click.echo(f"Saving to config file to {sdg.config}")
+            json.dump(kwargs, outfile)
     else:
-        if not obj.file.isatty():
-            output = mstmain(dataset=obj.file, size=obj.size)
-            click.echo(output.df, file=obj.out)
+        if not sdg.file.isatty():
+            output = mstmain(dataset=sdg.file, size=sdg.size, params=kwargs)
+            click.echo(output.df, file=sdg.out)
         else:
             print("here")
             mstcommand.main(["--help"])

--- a/src/reprosyn/methods/mbi/cli.py
+++ b/src/reprosyn/methods/mbi/cli.py
@@ -65,19 +65,18 @@ def mstcommand(sdg, **kwargs):
     rsyn mst < census.csv
     """
 
-    # all methods will need the config generation so this should be moved to a global method.
     if sdg.generateconfig:
         if sdg.config != "-":
-            sdg.set_config_path("mst")
-        with click.open_file(sdg.config, "w") as outfile:
-            click.echo(f"Saving to config file to {sdg.config}")
+            p = sdg.get_config_path()
+        with click.open_file(p, "w") as outfile:
+            click.echo(f"Saving to config file to {p}")
             json.dump(kwargs, outfile)
     else:
         if not sdg.file.isatty():
-            output = mstmain(dataset=sdg.file, size=sdg.size, params=kwargs)
+            output = mstmain(dataset=sdg.file, size=sdg.size, args=kwargs)
             click.echo(output.df, file=sdg.out)
         else:
-            print("here")
+            click.echo("Please give a dataset using --file or STDIN")
             mstcommand.main(["--help"])
 
 

--- a/src/reprosyn/methods/mbi/mst.py
+++ b/src/reprosyn/methods/mbi/mst.py
@@ -145,23 +145,6 @@ def reverse_data(data, supports):
     return Dataset(df, newdom)
 
 
-def default_params():
-    """
-    Return default parameters to run this program
-    :returns: a dictionary of default param settings for each command line arg
-    """
-    params = {}
-    params["dataset"] = "../data/adult.csv"
-    params["domain"] = "../data/adult-domain.json"
-    params["epsilon"] = 1.0
-    params["delta"] = 1e-9
-    params["degree"] = 2
-    params["num_marginals"] = None
-    params["max_cells"] = 10000
-
-    return params
-
-
 def get_domain_dict(data):
 
     return dict(zip(data.columns, data.nunique()))
@@ -179,7 +162,7 @@ def recode_as_category(data, columns=""):
     return data
 
 
-def mstmain(dataset, size):
+def mstmain(dataset, size, args):
 
     """Runs mst on given data
 
@@ -192,14 +175,15 @@ def mstmain(dataset, size):
     df = pd.read_csv(dataset)
     df = recode_as_category(drop_UID(df))
 
-    data = Dataset(df, Domain.fromdict(get_domain_dict(df)))
+    if not args.domain:
+        args.domain = get_domain_dict(df)
+
+    data = Dataset(df, Domain.fromdict(args.domain))
 
     # put temporary defaults in for now.
     # num_marginals = None
     # max_cells = 10000
     # degree = 2
-    delta = 1e-9
-    epsilon = 1.0
 
     # workload = list(itertools.combinations(data.domain, degree))
     # workload = [cl for cl in workload if data.domain.size(cl) <= max_cells]
@@ -212,7 +196,7 @@ def mstmain(dataset, size):
     click.echo("running MST...")
     if not size:
         size = len(df)
-    synth = MST(data, epsilon, delta, size)
+    synth = MST(data, args.epsilon, args.delta, size)
     click.echo(f"MST complete: {size} rows generated")
 
     return synth
@@ -221,28 +205,3 @@ def mstmain(dataset, size):
 if __name__ == "__main__":
 
     mstmain()
-
-    """
-    parser.add_argument("--dataset", help="dataset to use")
-    parser.add_argument("--domain", help="domain to use")
-    parser.add_argument("--epsilon", type=float, help="privacy parameter")
-    parser.add_argument("--delta", type=float, help="privacy parameter")
-
-    parser.add_argument("--degree", type=int,
-                        help="degree of marginals in workload")
-    parser.add_argument(
-        "--num_marginals", type=int, help="number of marginals in workload"
-    )
-    parser.add_argument(
-        "--max_cells",
-        type=int,
-        help="maximum number of cells for marginals in workload",
-    )
-
-    parser.add_argument("--save", type=str, help="path to save synthetic data")
-
-    parser.set_defaults(**default_params())
-    args = parser.parse_args()
-
-    """
-    # data = Dataset.load(args.dataset, args.domain)

--- a/src/reprosyn/methods/mbi/mst.py
+++ b/src/reprosyn/methods/mbi/mst.py
@@ -175,10 +175,10 @@ def mstmain(dataset, size, args):
     df = pd.read_csv(dataset)
     df = recode_as_category(drop_UID(df))
 
-    if not args.domain:
-        args.domain = get_domain_dict(df)
+    if not args["domain"]:
+        args["domain"] = get_domain_dict(df)
 
-    data = Dataset(df, Domain.fromdict(args.domain))
+    data = Dataset(df, Domain.fromdict(args["domain"]))
 
     # put temporary defaults in for now.
     # num_marginals = None
@@ -196,7 +196,7 @@ def mstmain(dataset, size, args):
     click.echo("running MST...")
     if not size:
         size = len(df)
-    synth = MST(data, args.epsilon, args.delta, size)
+    synth = MST(data, args["epsilon"], args["delta"], size)
     click.echo(f"MST complete: {size} rows generated")
 
     return synth


### PR DESCRIPTION
Closes #2 

If a config path is specified, we override the defaults of the corresponding subcommand using click's [default map](https://click.palletsprojects.com/en/8.1.x/commands/?highlight=ctx%20params#overriding-defaults).

This happens in the top-level cli with 
```
    if ctx.obj.config != "-":
        with click.open_file(ctx.obj.get_config_path(), "r") as f:
            config_params = json.load(f)
        ctx.default_map = {ctx.invoked_subcommand: config_params}
```

Since we are changing the defaults, cli options passed to the subcommand continue to operate as normal. 

Note that if `--generateconfig` is set, and a config file exists, then the config file will be overwritten with the defaults + config-specified defaults + command line options. We should prompt for this edge-case

