### PR TITLE
Merge to_csv() and drop_uid changes

### DIFF
--- a/src/reprosyn/methods/mbi/cli.py
+++ b/src/reprosyn/methods/mbi/cli.py
@@ -73,7 +73,7 @@ def mstcommand(sdg, **kwargs):
     else:
         if not sdg.file.isatty():
             output = mstmain(dataset=sdg.file, size=sdg.size, args=kwargs)
-            click.echo(output.df, file=sdg.out)
+            click.echo(output.df.to_csv(), file=sdg.out)
         else:
             click.echo("Please give a dataset using --file or STDIN")
             mstcommand.main(["--help"])

--- a/src/reprosyn/methods/mbi/mst.py
+++ b/src/reprosyn/methods/mbi/mst.py
@@ -150,11 +150,6 @@ def get_domain_dict(data):
     return dict(zip(data.columns, data.nunique()))
 
 
-def drop_UID(data, columns=["Person ID"]):
-    """Accepts list of UIDs we do not want to synthesise"""
-    return data.drop(columns, axis=1)
-
-
 def recode_as_category(data, columns=""):
     """Accepts list of column names to record as category"""
     for col in data.columns:
@@ -173,7 +168,7 @@ def mstmain(dataset, size, args):
     # load data
 
     df = pd.read_csv(dataset)
-    df = recode_as_category(drop_UID(df))
+    df = recode_as_category(df)
 
     if not args["domain"]:
         args["domain"] = get_domain_dict(df)


### PR DESCRIPTION
After @fhoussiau's testing of the Reprosyn -> PrivE example (see [this PR](https://github.com/alan-turing-institute/privacy-sdg-toolbox/pull/68)) two changes were made.

- dropping specific column naming and simply inferring the header. Any changes to the raw dataset should happen before it is passed to Reprosyn.
- outputting `output.df.to_csv()` rather than `output.df`