### PR TITLE
add generator.py file with class and wrapper

### DIFF
--- a/src/reprosyn/cli.py
+++ b/src/reprosyn/cli.py
@@ -4,38 +4,10 @@ from os import path, getcwd
 from datetime import datetime
 
 from reprosyn.methods.mbi.cli import mstcommand
+from reprosyn.generator import Generator
 
 import json
 from io import StringIO
-
-# Helper class for manipulating options across reprosyn
-
-
-class Generator(object):
-    def __init__(
-        self,
-        file=None,
-        out=None,
-        size=None,
-        generateconfig=None,
-        configpath=None,
-        configfolder=None,
-        configstring=None,
-    ):
-        self.file = file
-        self.out = out
-        self.size = size
-        self.generateconfig = generateconfig
-        self.configpath = configpath
-        self.configfolder = configfolder
-        self.configstring = configstring
-
-    def get_config_path(self):
-        if self.configpath != "-":
-            p = path.join(self.configfolder, self.configpath)
-        else:
-            p = self.configpath
-        return p
 
 
 @click.group(

--- a/src/reprosyn/generator.py
+++ b/src/reprosyn/generator.py
@@ -1,0 +1,50 @@
+import click
+from os import path
+import json
+
+# Helper class for manipulating options across reprosyn
+class Generator(object):
+    def __init__(
+        self,
+        file=None,
+        out=None,
+        size=None,
+        generateconfig=None,
+        configpath=None,
+        configfolder=None,
+        configstring=None,
+    ):
+        self.file = file
+        self.out = out
+        self.size = size
+        self.generateconfig = generateconfig
+        self.configpath = configpath
+        self.configfolder = configfolder
+        self.configstring = configstring
+
+    def get_config_path(self):
+        if self.configpath != "-":
+            p = path.join(self.configfolder, self.configpath)
+        else:
+            p = self.configpath
+        return p
+
+
+# Wrapper for any generator subcommand
+def wrap_generator(func):
+    @click.pass_obj
+    def wrapper(sdg, **kwargs):
+        if sdg.generateconfig:
+            p = sdg.get_config_path()
+            with click.open_file(p, "w") as outfile:
+                # click.echo(f"Saving to config file to {p}")
+                json.dump(kwargs, outfile)
+        else:
+            if not sdg.file.isatty():
+                df = func(sdg, **kwargs)
+                click.echo(df.to_csv(None, index=False), file=sdg.out)
+            else:
+                click.echo("Please give a dataset using --file or STDIN")
+                func.main(["--help"])
+
+    return wrapper

--- a/src/reprosyn/methods/mbi/cli.py
+++ b/src/reprosyn/methods/mbi/cli.py
@@ -1,6 +1,7 @@
 import click
 import json
 from reprosyn.methods.mbi.mst import mstmain
+from reprosyn.generator import wrap_generator
 
 # params = {}
 # params["dataset"] = "../data/adult.csv"
@@ -53,7 +54,7 @@ from reprosyn.methods.mbi.mst import mstmain
 #     default=10000,
 #     help="maximum number of cells for marginals in workload",
 # )
-@click.pass_obj
+@wrap_generator
 def mstcommand(sdg, **kwargs):
     """Runs MST on --file or STDIN
 
@@ -64,19 +65,8 @@ def mstcommand(sdg, **kwargs):
     rsyn --file census.csv mst  \n
     rsyn mst < census.csv
     """
-
-    if sdg.generateconfig:
-        p = sdg.get_config_path()
-        with click.open_file(p, "w") as outfile:
-            # click.echo(f"Saving to config file to {p}")
-            json.dump(kwargs, outfile)
-    else:
-        if not sdg.file.isatty():
-            output = mstmain(dataset=sdg.file, size=sdg.size, args=kwargs)
-            click.echo(output.df.to_csv(None, index=False), file=sdg.out)
-        else:
-            click.echo("Please give a dataset using --file or STDIN")
-            mstcommand.main(["--help"])
+    output = mstmain(dataset=sdg.file, size=sdg.size, args=kwargs)
+    return output.df
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #13 

Changes:
- We now have a wrapper function that any new command should use as a decorator (we should document this, #23). 
- I have moved this, and the `Generator` class, which is really just a convenient way of passing parameters, to a `generator.py` file in the root directory, to keep the `cli.py` files solely for the click cli. 


