### PR TITLE
metadata file loading TextIOWrapper

### DIFF
--- a/src/reprosyn/dataset.py
+++ b/src/reprosyn/dataset.py
@@ -135,7 +135,7 @@ class Dataset:
         if isinstance(metadata, list):
             return metadata
         elif isinstance(metadata, io.TextIOWrapper):
-            return json.loads(metadata)
+            return json.load(metadata)
         elif path.isfile(metadata):
             return json.loads(metadata)
         elif _is_url(metadata):

--- a/src/reprosyn/methods/gans/pate_gan.py
+++ b/src/reprosyn/methods/gans/pate_gan.py
@@ -47,6 +47,7 @@ class PateGan(GenerativeModel):
         batch_size=128,
         learning_rate=1e-4,
         multiprocess=False,
+        **kw,
     ):
         """
         :param metadata: dict: Attribute metadata describing the data domain of the synthetic target data


### PR DESCRIPTION
Hello. Calling rsyn cli with the metadata option raises the error `TypeError: the JSON object must be str, bytes or bytearray, not TextIOWrapper`. I think one should call `json.load` rather than `json.loads` with `io.TextIOWrapper`. This change fixes the issue.